### PR TITLE
fix: Opening local files with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1]
+
+### 2025-05-28
+
+- Fix opening local files with special characters.
+
 ## [1.0.0]
 
 ### 2025-03-14

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In your app-level gradle file, import the `ion-android-fileviewer` library like 
 
 ```
 dependencies {
-    implementation("io.ionic.libs:ionfileviewer-android:1.0.0")
+    implementation("io.ionic.libs:ionfileviewer-android:1.0.1")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionfileviewer-android</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </project>

--- a/src/main/kotlin/io/ionic/libs/ionfileviewerlib/IONFLVWController.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfileviewerlib/IONFLVWController.kt
@@ -7,7 +7,6 @@ import io.ionic.libs.ionfileviewerlib.helpers.IONFLVWInputsValidator
 import io.ionic.libs.ionfileviewerlib.helpers.IONFLVWOpenDocumentHelper
 import io.ionic.libs.ionfileviewerlib.helpers.runCatchingIONFLVWExceptions
 import io.ionic.libs.ionfileviewerlib.model.IONFLVWException
-import kotlin.concurrent.thread
 
 /**
  * Entry point in IONFileViewerLib-Android
@@ -41,8 +40,8 @@ class IONFLVWController internal constructor(
         if (!inputsValidator.isPathValid(filePath)) {
             throw IONFLVWException.InvalidPath(filePath)
         }
-        val filePathNoSpaces: String = filePath.replace("%20| ".toRegex(), "\\ ")
-        openDocumentHelper.openDocumentFromLocalPath(activity, filePathNoSpaces)
+        val filePathNormalized: String = inputsValidator.normalizeFilePath(filePath)
+        openDocumentHelper.openDocumentFromLocalPath(activity, filePathNormalized)
     }
 
     /**

--- a/src/main/kotlin/io/ionic/libs/ionfileviewerlib/helpers/IONFLVWInputsValidator.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfileviewerlib/helpers/IONFLVWInputsValidator.kt
@@ -1,6 +1,9 @@
 package io.ionic.libs.ionfileviewerlib.helpers
 
+import android.net.Uri
 import android.os.Looper
+import androidx.core.net.toUri
+import io.ionic.libs.ionfileviewerlib.model.IONFLVWException
 import java.util.regex.Pattern
 
 class IONFLVWInputsValidator {
@@ -29,4 +32,17 @@ class IONFLVWInputsValidator {
      * @return true if in main thread, false otherwise
      */
     fun isInMainThread(): Boolean = Looper.getMainLooper().isCurrentThread
+
+    /**
+     * Normalizes a file path before opening it.
+     * This means verifying the fields are URL decoded, while making sure we're not trying to decode already decoded fields
+     *
+     * @param filePath the file path to normalize
+     * @throws IONFLVWException.InvalidPath if unable to normalize the file path
+     * @return the normalized file path, with special characters decoded.
+     */
+    fun normalizeFilePath(filePath: String): String {
+        val filePathToNormalize = Uri.encode(Uri.decode(filePath))
+        return filePathToNormalize.toUri().path ?: throw IONFLVWException.InvalidPath(filePath)
+    }
 }

--- a/src/main/kotlin/io/ionic/libs/ionfileviewerlib/helpers/IONFLVWOpenDocumentHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfileviewerlib/helpers/IONFLVWOpenDocumentHelper.kt
@@ -3,9 +3,9 @@ package io.ionic.libs.ionfileviewerlib.helpers
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.net.Uri
 import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
+import androidx.core.net.toUri
 import java.io.File
 import java.io.FileNotFoundException
 
@@ -52,7 +52,7 @@ internal class IONFLVWOpenDocumentHelper {
      */
     @Throws(ActivityNotFoundException::class)
     fun openDocumentFromURL(activity: Activity, url: String) {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
         activity.startActivity(intent)
     }
 


### PR DESCRIPTION
## Description

If you tried to open a file with special characters, e.g. "file#name.txt", via a [filesystem native library](https://github.com/ionic-team/ion-android-filesystem) URI, the uri would come with special characters encoded, and the file would not be found.

The fix is similar to the one for [file transfer](https://github.com/ionic-team/ion-android-filetransfer/pull/6/files).

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

I tested with a local build, by replacing the library with a local .aar generated from this branch; let me know if you want an actual OutSystems app.


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
