### PR TITLE
fix: OSSRH to Central Portal migration

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Make local props
         run: |
           cat << EOF > "local.properties"
-          ossrhUsername=${{ secrets.ANDROID_OSSRH_USERNAME }}
-          ossrhPassword=${{ secrets.ANDROID_OSSRH_PASSWORD }}
+          centralTokenUsername=${{ secrets.ANDROID_CENTRAL_USERNAME }}
+          centralTokenPassword=${{ secrets.ANDROID_CENTRAL_PASSWORD }}
           sonatypeStagingProfileId=${{ secrets.ANDROID_SONATYPE_STAGING_PROFILE_ID }}
           signing.keyId=${{ secrets.ANDROID_SIGNING_KEY_ID }}
           signing.password=${{ secrets.ANDROID_SIGNING_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2]
+
+### 2025-06-24
+
+- Migrate publishing from OSSRH to Central Portal.
+
 ## [1.0.1]
 
 ### 2025-05-28

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In your app-level gradle file, import the `ion-android-fileviewer` library like 
 
 ```
 dependencies {
-    implementation("io.ionic.libs:ionfileviewer-android:1.0.1")
+    implementation("io.ionic.libs:ionfileviewer-android:1.0.2")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionfileviewer-android</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 </project>

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -30,7 +30,7 @@ else
     if grep --quiet "BUILD SUCCESSFUL" $LOG_OUTPUT; then
         printf %"s\n" "Success: Published to MavenCentral."
     else
-        printf %"s\n" "Error publishing, check $LOG_OUTPUT for more info! Manually review and release from the Sonatype Repository Manager may be necessary https://s01.oss.sonatype.org/"
+        printf %"s\n" "Error publishing, check $LOG_OUTPUT for more info! Manually review and release from the Central Portal may be necessary https://central.sonatype.com/publishing/deployments/"
         cat $LOG_OUTPUT
         exit 1
     fi

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -2,8 +2,8 @@
 ext["signing.keyId"] = ''
 ext["signing.key"] = ''
 ext["signing.password"] = ''
-ext["ossrhUsername"] = ''
-ext["ossrhPassword"] = ''
+ext["centralTokenUsername"] = ''
+ext["centralTokenPassword"] = ''
 ext["sonatypeStagingProfileId"] = ''
 
 File secretPropsFile = file('./local.properties')
@@ -14,8 +14,8 @@ if (secretPropsFile.exists()) {
     p.each { name, value -> ext[name] = value }
 } else {
     // Use system environment variables
-    ext["ossrhUsername"] = System.getenv('ANDROID_OSSRH_USERNAME')
-    ext["ossrhPassword"] = System.getenv('ANDROID_OSSRH_PASSWORD')
+    ext["centralTokenUsername"] = System.getenv('ANDROID_CENTRAL_USERNAME')
+    ext["centralTokenPassword"] = System.getenv('ANDROID_CENTRAL_PASSWORD')
     ext["sonatypeStagingProfileId"] = System.getenv('ANDROID_SONATYPE_STAGING_PROFILE_ID')
     ext["signing.keyId"] = System.getenv('ANDROID_SIGNING_KEY_ID')
     ext["signing.key"] = System.getenv('ANDROID_SIGNING_KEY')
@@ -27,10 +27,10 @@ nexusPublishing {
     repositories {
         sonatype {
             stagingProfileId = sonatypeStagingProfileId
-            username = ossrhUsername
-            password = ossrhPassword
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = centralTokenUsername
+            password = centralTokenPassword
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
     repositoryDescription = 'IONFileViewerLib Android Lib v' + System.getenv('THE_VERSION')


### PR DESCRIPTION
## Description

We currently publish the library in Maven Central through OSSRH, however this needs to be changed due OSSRH being shutdown in after June 30th 2025.

Migration of `io.ionic` namespace to Central Portal has already been done, this PR takes care of updating the publishing logic - which uses a new token that is now accessed in different github secrets.

A similar PR will be replicated to other repositories of ours, after this one is merged - The one thing I won't do is update to a new release, this is more because this is the first time we're making this change, therefore we shall test the e2e release flow entirely in this repo.

Relevant References:

- https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/
- https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

Tested publishing `1.0.1-dev.1` (first publishing to staging repository) and `1.0.1-dev.2` (skipping staging repository), both arrived to Central Portal.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
